### PR TITLE
fix(scripts): resolve workspace root via go.work in contract checks

### DIFF
--- a/scripts/run_contract_check.sh
+++ b/scripts/run_contract_check.sh
@@ -10,8 +10,24 @@ surface="$1"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 product_root="$(cd "$script_dir/.." && pwd)"
-workspace_root="$(cd "$product_root/.." && pwd)"
-devtools_repo="$workspace_root/platformkit-devtools"
+
+# The workspace root is the directory holding go.work (the layered layout
+# puts this repo at <root>/product/platformkit, so walk upward rather than
+# assuming a flat sibling topology).
+workspace_root="$product_root"
+while [[ "$workspace_root" != "/" && ! -f "$workspace_root/go.work" ]]; do
+	workspace_root="$(cd "$workspace_root/.." && pwd)"
+done
+if [[ ! -f "$workspace_root/go.work" ]]; then
+	echo "could not locate workspace root (no go.work above $product_root)" >&2
+	exit 2
+fi
+
+devtools_repo="$workspace_root/tooling/platformkit-devtools"
+if [[ ! -d "$devtools_repo" ]]; then
+	# pre-layered flat layout fallback
+	devtools_repo="$workspace_root/platformkit-devtools"
+fi
 
 require_dir() {
 	local dir="$1"
@@ -34,7 +50,7 @@ mkdir -p "$cli_go_cache" "$cli_go_modcache" "$cli_go_tmp" "$cli_go_path"
 (
 	cd "$devtools_repo"
 	env \
-		GOWORK=off \
+		GOWORK="$workspace_root/go.work" \
 		GOPATH="$cli_go_path" \
 		GOCACHE="$cli_go_cache" \
 		GOMODCACHE="$cli_go_modcache" \


### PR DESCRIPTION
Found while measuring the verification matrix: `verify-product`/`verify-federated-platform` failed instantly on clean main — the runner hardcoded the pre-reorg flat topology (workspace root = repo parent, devtools as sibling) so its pre-flight guard aborted before any check ran. Now walks up to the `go.work` root, finds devtools under `tooling/` (flat fallback kept), and resolves siblings via the workspace `go.work` instead of `GOWORK=off` (stale go.sum for replace-directive siblings was the next latent break). The chain now executes real checks; the first one (backend-interoperability) fails for separate reasons and is tracked as its own item.